### PR TITLE
Composer dependency php >= 7.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,14 +14,14 @@ on:
 
 jobs:
   cs:
-    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2"]'
+      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
 
   stan:
-    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v1
+    uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2"]'
+      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
 
   unit:
     name: 'Run unit tests'
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4, 8.1, 8.2]
+        php-version: [7.4, 8.1, 8.2, 8.3]
 
     steps:
       - name: 'Checkout current revision'
@@ -72,8 +72,9 @@ jobs:
           filename: 'clover.xml'
 
       - name: 'Export coverage results'
-        uses: 'codecov/codecov-action@v3'
+        uses: 'codecov/codecov-action@v4'
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: './clover.xml'
           env_vars: PHP_VERSION
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   release-job:
-    uses: bedita/github-workflows/.github/workflows/release.yml@v1
+    uses: bedita/github-workflows/.github/workflows/release.yml@v2
     with:
       main_branch: 'main'
       dist_branches: '["main"]'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The recommended way to install composer packages is:
 composer require bedita/i18n-microsoft
 ```
 
-Note: php version supported is >= 7.4 and < 8.3.
+Note: php version supported is >= 7.4.
 
 ## Microsoft Translator TEXT API
 

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
     "name": "bedita/i18n-microsoft",
-    "description": "BEdita I18n Microsoft plugin supporting PHP >= 7.3 && PHP < 8.3",
+    "description": "BEdita I18n Microsoft plugin supporting PHP >= 7.4",
     "license": "MIT",
     "require": {
-        "php": ">=7.4 <8.3",
+        "php": ">=7.4",
         "bedita/i18n": "^4.4.3",
         "cakephp/utility": "^4.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3",
         "phpstan/phpstan": "^1.10",
-        "cakephp/cakephp-codesniffer": "^5.1",
+        "cakephp/cakephp-codesniffer": "~4.7.0",
         "cakephp/cakephp": "^4.4"
     },
     "autoload": {


### PR DESCRIPTION
This updates composer dependency php >= 7.4, to allow php 8.3 too.

This also update github workflows to use bedita github-workflows v2 and php 8.3

Fix cs using `"cakephp/cakephp-codesniffer": "~4.7.0"`