### PR TITLE
Prepare major release 1: php >= 8.1, cakephp 4.5, bedita/i18n >= 5.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gh-actions:
+        patterns: ['actions/*']
+      docker:
+        patterns: ['docker/*']
+      codecov:
+        patterns: ['codecov/*']

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,12 +16,12 @@ jobs:
   cs:
     uses: bedita/github-workflows/.github/workflows/php-cs.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   stan:
     uses: bedita/github-workflows/.github/workflows/php-stan.yml@v2
     with:
-      php_versions: '["7.4", "8.1", "8.2", "8.3"]'
+      php_versions: '["8.3"]'
 
   unit:
     name: 'Run unit tests'
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [7.4, 8.1, 8.2, 8.3]
+        php-version: [8.1, 8.2, 8.3]
 
     steps:
       - name: 'Checkout current revision'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The recommended way to install composer packages is:
 composer require bedita/i18n-microsoft
 ```
 
-Note: php version supported is >= 7.4.
+Note: php version supported is >= 8.1.
 
 ## Microsoft Translator TEXT API
 

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,17 @@
 {
     "name": "bedita/i18n-microsoft",
-    "description": "BEdita I18n Microsoft plugin supporting PHP >= 7.4",
+    "description": "BEdita I18n Microsoft plugin supporting PHP >= 8.1",
     "license": "MIT",
     "require": {
-        "php": ">=7.4",
-        "bedita/i18n": "^4.4.3",
-        "cakephp/utility": "^4.4"
+        "php": ">=8.1",
+        "bedita/i18n": "^5.0.0",
+        "cakephp/utility": "^4.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^9.6",
         "phpstan/phpstan": "^1.10",
         "cakephp/cakephp-codesniffer": "~4.7.0",
-        "cakephp/cakephp": "^4.4"
+        "cakephp/cakephp": "^4.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This introduces some breaking changes:

 - php >= 8.1
 - cakephp >= 4.5
 - bedita/i18n >= 5.0.0